### PR TITLE
feat: support img tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ function action(data) {
 
     // ![example](postname/example.jpg)  -->  {% asset_img example.jpg example %}
     var regExp = RegExp("!\\[(.*?)\\]\\(" + fileName + '/(.+?)\\)', "g");
+    var imgExp = RegExp("(<img\s*?.*?\s*?src=\")" + fileName + "/(.+?\".*?>)")
     // hexo g
     data.content = data.content.replace(regExp, "{% asset_img $2 $1 %}","g");
-
+    data.content = data.content.replace(imgExp, "$1$2", "g")
     // log.info(`hexo-asset-img: filename: ${fileName}, title: ${data.title.trim()}`);
     
     return data;


### PR DESCRIPTION
Add a RegExp to match and replace HTML `img` tag which allows user to customize image styles.
Version：
"hexo": {
    "version": "6.3.0"
  },
  "dependencies": {
    "@waline/hexo-next": "^3.0.1",
    "hexo": "^6.3.0",
    "hexo-asset-img": "^1.0.0",
    "hexo-deployer-git": "^3.0.0",
    "hexo-excerpt": "^1.3.0",
    "hexo-filter-mermaid-diagrams": "^1.0.5",
    "hexo-generator-archive": "^1.0.0",
    "hexo-generator-category": "^1.0.0",
    "hexo-generator-index": "^2.0.0",
    "hexo-generator-searchdb": "^1.4.0",
    "hexo-generator-tag": "^1.0.0",
    "hexo-next-twikoo": "^1.0.3",
    "hexo-renderer-ejs": "^2.0.0",
    "hexo-renderer-marked": "^6.0.0",
    "hexo-renderer-stylus": "^2.1.0",
    "hexo-server": "^3.0.0",
    "hexo-theme-landscape": "^0.0.3"
  }