### PR TITLE
feat: support img tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const log = require('hexo-log')({ 'debug': false, 'slient': false });
+const htmlparser2 = require("htmlparser2");
 
 /**
  * md文件返回 true
@@ -11,16 +12,39 @@ function ignore(data) {
     return ['md',].indexOf(ext) > -1;
 }
 
+function random(length) { // generate random string
+    res = ''
+    letters = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
+    for (let i = 0; i < length; i++) {
+        let index = Math.round(Math.random() * 25)
+        res += letters[index];
+    }
+    return res
+}
+
+function transform(img, fileName) {
+    img = htmlparser2.parseDocument(img, "text/html").children[0]
+    src = img.attribs.src
+    title = img.attribs.title ? img.attribs.title : ""
+    alt = img.attribs.alt ? img.attribs.alt : ""
+    style = img.attribs.style ? img.attribs.style : ""
+    imgFile = src.match(RegExp(".*?" + fileName + "/(.+?)$"))[1]
+    className = random(12)
+    imgTag = "{% asset_img " + className + " " + imgFile + " \'\"" + title + "\"\"" + alt + "\"\' %}"
+    styleTag = "<style>." + className + "{" + style + "}</style>"
+    return styleTag + imgTag
+}
+
 function action(data) {
     var reverseSource = data.source.split("").reverse().join("");
     var fileName = reverseSource.substring(3, reverseSource.indexOf("/")).split("").reverse().join("");
 
     // ![example](postname/example.jpg)  -->  {% asset_img example.jpg example %}
     var regExp = RegExp("!\\[(.*?)\\]\\(" + fileName + '/(.+?)\\)', "g");
-    var imgExp = RegExp("(<img\s*?.*?\s*?src=\")" + fileName + "/(.+?\".*?>)", "g")
+    var imgExp = RegExp("(<img.*?src=\"" + fileName + "/.+?\".*?>)", "g")
     // hexo g
     data.content = data.content.replace(regExp, "{% asset_img $2 $1 %}", "g");
-    data.content = data.content.replace(imgExp, "$1$2", "g")
+    data.content = data.content.replace(imgExp, (match, img) => {return transform(img, fileName)}, "g")
     // log.info(`hexo-asset-img: filename: ${fileName}, title: ${data.title.trim()}`);
     
     return data;

--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ function action(data) {
 
     // ![example](postname/example.jpg)  -->  {% asset_img example.jpg example %}
     var regExp = RegExp("!\\[(.*?)\\]\\(" + fileName + '/(.+?)\\)', "g");
+    var imgExp = RegExp("(<img\s*?.*?\s*?src=\")" + fileName + "/(.+?\".*?>)", "g")
     // hexo g
-    data.content = data.content.replace(regExp, "{% asset_img $2 $1 %}","g");
-
+    data.content = data.content.replace(regExp, "{% asset_img $2 $1 %}", "g");
+    data.content = data.content.replace(imgExp, "$1$2", "g")
     // log.info(`hexo-asset-img: filename: ${fileName}, title: ${data.title.trim()}`);
     
     return data;


### PR DESCRIPTION
Support HTML img tag like `<img src="xxx/yyy.jpg" style="..." title="...">` where xxx is the post's name.

Basic idea: 
- randomly generate a class `zzz` for each image and add `<style> .zzz{...}</style>`  in the markdown file
- tansform html img tag `<img>` to hexo image tag `{% asset_img zzz xxx '"title""alt"' %}`

Version：
"hexo": {
"version": "6.3.0"
},
"dependencies": {
"@waline/hexo-next": "^3.0.1",
"hexo": "^6.3.0",
"hexo-asset-img": "^1.0.0",
"hexo-deployer-git": "^3.0.0",
"hexo-excerpt": "^1.3.0",
"hexo-filter-mermaid-diagrams": "^1.0.5",
"hexo-generator-archive": "^1.0.0",
"hexo-generator-category": "^1.0.0",
"hexo-generator-index": "^2.0.0",
"hexo-generator-searchdb": "^1.4.0",
"hexo-generator-tag": "^1.0.0",
"hexo-next-twikoo": "^1.0.3",
"hexo-renderer-ejs": "^2.0.0",
"hexo-renderer-marked": "^6.0.0",
"hexo-renderer-stylus": "^2.1.0",
"hexo-server": "^3.0.0",
"hexo-theme-landscape": "^0.0.3"
}