### PR TITLE
Update index.js 处理 <img> 标签中特殊字符导致的解析错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function action(data) {
      */
 
     var regExp = RegExp("!\\[(.*?)\\]\\(<?" + fileName + '/(.+?)>?\\)', "g");
-    var imgExp = RegExp("(<img.*?src=\"" + fileName + "/.+?\".*?>)", "g")
+    var imgExp = RegExp("(<img.*?src=\"" + fileName + "/.+?\".*?/>)", "g")
 
     data.content = data.content.replace(regExp, "![$1]($2)", "g");
 


### PR DESCRIPTION
当碰见这样的 img 标签的时候

`<img src="TryHackMe_靶机优化指北/image-20250920025154246.png" alt="北京联通 -> Misaka 德国" style="zoom:50%;" />`

会报错

> TypeError: Cannot read properties of undefined (reading 'attribs')
    at transform (D:\SyncFolder\_blog_hexo\node_modules\hexo-asset-img\index.js:34:15)
    at D:\SyncFolder\_blog_hexo\node_modules\hexo-asset-img\index.js:69:73
    at String.replace (<anonymous>)
    at action (D:\SyncFolder\_blog_hexo\node_modules\hexo-asset-img\index.js:69:33)
    at Hexo.<anonymous> (D:\SyncFolder\_blog_hexo\node_modules\hexo-asset-img\index.js:76:9)
    at Hexo.tryCatcher (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\util.js:16:23)
    at Hexo.<anonymous> (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\method.js:15:34)
    at D:\SyncFolder\_blog_hexo\node_modules\hexo\lib\extend\filter.ts:87:52
    at tryCatcher (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\util.js:16:23)
    at Object.gotValue (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\reduce.js:166:18)
    at Object.gotAccum (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\reduce.js:155:25)
    at Object.tryCatcher (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\util.js:16:23)
    at Promise._settlePromiseFromHandler (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\promise.js:547:31)
    at Promise._settlePromise (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\promise.js:604:18)
    at Promise._settlePromiseCtx (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\promise.js:641:10)
    at _drainQueueStep (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\async.js:97:12)
    at _drainQueue (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\async.js:86:9)
    at Async._drainQueues (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (D:\SyncFolder\_blog_hexo\node_modules\bluebird\js\release\async.js:15:14)
    at processImmediate (node:internal/timers:485:21)

因为里面含有 `>` 导致提前匹配到了。

解决办法是修改匹配结尾字符为 `/>` 即严格匹配 `img` 标签以 `/>` 结尾，问题解决。